### PR TITLE
Add tables listing tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # bigquery-mcp-server
 
-This repository provides a minimal Model Context Protocol (MCP) server written in Go. The server exposes two tools backed by Google BigQuery:
+This repository provides a minimal Model Context Protocol (MCP) server written in Go. The server exposes three tools backed by Google BigQuery:
 
 - `schema` – returns the schema of a BigQuery table
 - `query` – executes an SQL query and returns the result rows
+- `tables` – lists tables in a BigQuery dataset
 
 ## Requirements
 

--- a/internal/bigquery/client.go
+++ b/internal/bigquery/client.go
@@ -10,6 +10,7 @@ import (
 type Client interface {
 	GetTableSchema(ctx context.Context, datasetID, tableID string) ([]*bigquery.FieldSchema, error)
 	RunQuery(ctx context.Context, sql string) ([]map[string]bigquery.Value, error)
+	ListTables(ctx context.Context, datasetID string) ([]string, error)
 }
 
 type realClient struct {
@@ -53,4 +54,20 @@ func (r *realClient) RunQuery(ctx context.Context, sql string) ([]map[string]big
 		results = append(results, row)
 	}
 	return results, nil
+}
+
+func (r *realClient) ListTables(ctx context.Context, datasetID string) ([]string, error) {
+	it := r.client.Dataset(datasetID).Tables(ctx)
+	var tables []string
+	for {
+		tbl, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		tables = append(tables, tbl.TableID)
+	}
+	return tables, nil
 }

--- a/internal/bigquery/mock.go
+++ b/internal/bigquery/mock.go
@@ -9,6 +9,7 @@ import (
 type MockClient struct {
 	SchemaRes []*bigquery.FieldSchema
 	QueryRes  []map[string]bigquery.Value
+	TablesRes []string
 	Err       error
 }
 
@@ -18,4 +19,8 @@ func (m *MockClient) GetTableSchema(ctx context.Context, datasetID, tableID stri
 
 func (m *MockClient) RunQuery(ctx context.Context, sql string) ([]map[string]bigquery.Value, error) {
 	return m.QueryRes, m.Err
+}
+
+func (m *MockClient) ListTables(ctx context.Context, datasetID string) ([]string, error) {
+	return m.TablesRes, m.Err
 }

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -51,3 +51,21 @@ func TestQueryHandler(t *testing.T) {
 		t.Fatalf("unexpected rows: %#v", rows)
 	}
 }
+
+func TestTablesHandler(t *testing.T) {
+	mock := &bq.MockClient{TablesRes: []string{"t1"}}
+	srv := NewServer(func(ctx context.Context, project string) (bq.Client, error) { return mock, nil })
+
+	res, err := srv.tablesHandler(context.Background(), mcp.CallToolRequest{}, tablesArgs{Project: "p", Dataset: "d"})
+	if err != nil {
+		t.Fatalf("tablesHandler error: %v", err)
+	}
+	var tables []string
+	tc, _ := mcp.AsTextContent(res.Content[0])
+	if err := json.Unmarshal([]byte(tc.Text), &tables); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(tables) != 1 || tables[0] != "t1" {
+		t.Fatalf("unexpected tables: %#v", tables)
+	}
+}


### PR DESCRIPTION
## Summary
- support listing dataset tables in BigQuery
- register new `tables` tool in the MCP server
- document usage and test new handler

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684d2e92a55c83299ee32f5c61c544b4