### PR TITLE
Add BigQuery dry run tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # bigquery-mcp-server
 
-This repository provides a minimal Model Context Protocol (MCP) server written in Go. The server exposes two tools backed by Google BigQuery:
+This repository provides a minimal Model Context Protocol (MCP) server written in Go. The server exposes tools backed by Google BigQuery:
 
 - `schema` – returns the schema of a BigQuery table
 - `query` – executes an SQL query and returns the result rows
+- `dryrun` – performs a BigQuery dry run to validate SQL and estimate costs
 
 ## Requirements
 

--- a/internal/bigquery/mock.go
+++ b/internal/bigquery/mock.go
@@ -9,6 +9,7 @@ import (
 type MockClient struct {
 	SchemaRes []*bigquery.FieldSchema
 	QueryRes  []map[string]bigquery.Value
+	DryRunRes *bigquery.QueryStatistics
 	Err       error
 }
 
@@ -18,4 +19,8 @@ func (m *MockClient) GetTableSchema(ctx context.Context, datasetID, tableID stri
 
 func (m *MockClient) RunQuery(ctx context.Context, sql string) ([]map[string]bigquery.Value, error) {
 	return m.QueryRes, m.Err
+}
+
+func (m *MockClient) DryRunQuery(ctx context.Context, sql string) (*bigquery.QueryStatistics, error) {
+	return m.DryRunRes, m.Err
 }


### PR DESCRIPTION
## Summary
- add `DryRunQuery` to bigquery client and mock
- implement `dryrun` tool in MCP server
- update handler tests
- document the new tool in README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684d2e7c800c832992edd4ea8cfb6ed8