### PR TITLE
Add tables tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository provides a minimal Model Context Protocol (MCP) server written i
 - `schema` – returns the schema of a BigQuery table
 - `query` – executes an SQL query and returns the result rows
 - `dryrun` – performs a BigQuery dry run to validate SQL and estimate costs
+- `tables` – lists tables in a BigQuery dataset
 
 ## Requirements
 

--- a/internal/bigquery/client.go
+++ b/internal/bigquery/client.go
@@ -12,6 +12,7 @@ type Client interface {
 	GetTableSchema(ctx context.Context, datasetID, tableID string) ([]*bigquery.FieldSchema, error)
 	RunQuery(ctx context.Context, sql string) ([]map[string]bigquery.Value, error)
 	DryRunQuery(ctx context.Context, sql string) (*bigquery.QueryStatistics, error)
+	ListTables(ctx context.Context, datasetID string) ([]string, error)
 }
 
 type realClient struct {
@@ -73,4 +74,20 @@ func (r *realClient) DryRunQuery(ctx context.Context, sql string) (*bigquery.Que
 		return nil, errors.New("no query statistics")
 	}
 	return qs, nil
+}
+
+func (r *realClient) ListTables(ctx context.Context, datasetID string) ([]string, error) {
+	it := r.client.Dataset(datasetID).Tables(ctx)
+	var tables []string
+	for {
+		tbl, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		tables = append(tables, tbl.TableID)
+	}
+	return tables, nil
 }

--- a/internal/bigquery/mock.go
+++ b/internal/bigquery/mock.go
@@ -10,6 +10,7 @@ type MockClient struct {
 	SchemaRes []*bigquery.FieldSchema
 	QueryRes  []map[string]bigquery.Value
 	DryRunRes *bigquery.QueryStatistics
+	TablesRes []string
 	Err       error
 }
 
@@ -23,4 +24,8 @@ func (m *MockClient) RunQuery(ctx context.Context, sql string) ([]map[string]big
 
 func (m *MockClient) DryRunQuery(ctx context.Context, sql string) (*bigquery.QueryStatistics, error) {
 	return m.DryRunRes, m.Err
+}
+
+func (m *MockClient) ListTables(ctx context.Context, datasetID string) ([]string, error) {
+	return m.TablesRes, m.Err
 }

--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -32,6 +32,11 @@ type dryRunArgs struct {
 	SQL     string `json:"sql"`
 }
 
+type tablesArgs struct {
+	Project string `json:"project"`
+	Dataset string `json:"dataset"`
+}
+
 func NewServer(provider func(ctx context.Context, project string) (bigquery.Client, error)) *Server {
 	mcpSrv := server.NewMCPServer(
 		"bigquery-mcp-server",
@@ -61,6 +66,13 @@ func NewServer(provider func(ctx context.Context, project string) (bigquery.Clie
 		mcp.WithString("project", mcp.Required()),
 		mcp.WithString("sql", mcp.Required()),
 	), mcp.NewTypedToolHandler(s.dryRunHandler))
+
+	mcpSrv.AddTool(mcp.NewTool(
+		"tables",
+		mcp.WithDescription("List BigQuery tables in a dataset"),
+		mcp.WithString("project", mcp.Required()),
+		mcp.WithString("dataset", mcp.Required()),
+	), mcp.NewTypedToolHandler(s.tablesHandler))
 
 	s.httpServer = server.NewStreamableHTTPServer(mcpSrv)
 	return s
@@ -106,5 +118,18 @@ func (s *Server) dryRunHandler(ctx context.Context, _ mcp.CallToolRequest, args 
 		return nil, err
 	}
 	data, _ := json.Marshal(stats)
+	return mcp.NewToolResultText(string(data)), nil
+}
+
+func (s *Server) tablesHandler(ctx context.Context, _ mcp.CallToolRequest, args tablesArgs) (*mcp.CallToolResult, error) {
+	c, err := s.bqClientProvider(ctx, args.Project)
+	if err != nil {
+		return nil, err
+	}
+	tables, err := c.ListTables(ctx, args.Dataset)
+	if err != nil {
+		return nil, err
+	}
+	data, _ := json.Marshal(tables)
 	return mcp.NewToolResultText(string(data)), nil
 }

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -69,3 +69,21 @@ func TestDryRunHandler(t *testing.T) {
 		t.Fatalf("unexpected stats: %#v", stats)
 	}
 }
+
+func TestTablesHandler(t *testing.T) {
+	mock := &bq.MockClient{TablesRes: []string{"t1", "t2"}}
+	srv := NewServer(func(ctx context.Context, project string) (bq.Client, error) { return mock, nil })
+
+	res, err := srv.tablesHandler(context.Background(), mcp.CallToolRequest{}, tablesArgs{Project: "p", Dataset: "d"})
+	if err != nil {
+		t.Fatalf("tablesHandler error: %v", err)
+	}
+	tc, _ := mcp.AsTextContent(res.Content[0])
+	var tables []string
+	if err := json.Unmarshal([]byte(tc.Text), &tables); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(tables) != 2 || tables[0] != "t1" || tables[1] != "t2" {
+		t.Fatalf("unexpected tables: %#v", tables)
+	}
+}


### PR DESCRIPTION
## Summary
- add new ListTables method to the BigQuery client
- expose `tables` tool to list tables in a dataset
- test new handler and update e2e tests
- document the new tool in the README

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e28c1647883298dbb8cec8cd1b4ef