### PR TITLE
Implement query scan limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ go run ./cmd/server
 
 The server listens on `:8080` by default. Use an MCP client to call the registered tools.
 
+### Limiting Query Cost
+
+Set the environment variable `MAX_BQ_QUERY_BYTES` to limit how many bytes a query may scan. The `query` tool performs a BigQuery dry run and refuses to execute if the estimated bytes processed exceed this value.
+
 ## Testing
 
 Run unit tests:


### PR DESCRIPTION
## Summary
- add env var `MAX_BQ_QUERY_BYTES` to guard query execution by running a dry run
- document the new environment variable
- test query limit behaviour

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e36e267448329a82f1e0bfd115e0c