### PR TITLE
Add tools for executing SQL from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ This repository provides a minimal Model Context Protocol (MCP) server written i
 - `schema` – returns the schema of a BigQuery table
 - `query` – executes an SQL query and returns the result rows
 - `dryrun` – performs a BigQuery dry run to validate SQL and estimate costs
+- `queryfile` – executes SQL read from a file
+- `dryrunfile` – dry runs SQL read from a file
 - `tables` – lists tables in a BigQuery dataset
 
 ## Requirements

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -1,6 +1,6 @@
 # E2E Testing Strategy
 
-This project implements the Model Context Protocol (MCP) with two BigQuery backed tools.
+This project implements the Model Context Protocol (MCP) with several BigQuery backed tools.
 Typical MCP server tests verify:
 
 1. **Initialization** – the client can negotiate protocol version and obtain server capabilities.

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"testing"
 
 	"cloud.google.com/go/bigquery"
@@ -52,6 +53,33 @@ func TestQueryHandler(t *testing.T) {
 	}
 }
 
+func TestQueryFileHandler(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "q*.sql")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	if _, err := tmp.WriteString("SELECT 1"); err != nil {
+		t.Fatalf("write temp sql: %v", err)
+	}
+	tmp.Close()
+
+	mock := &bq.MockClient{QueryRes: []map[string]bigquery.Value{{"id": "1"}}}
+	srv := NewServer(func(ctx context.Context, project string) (bq.Client, error) { return mock, nil })
+
+	res, err := srv.queryFileHandler(context.Background(), mcp.CallToolRequest{}, queryFileArgs{Project: "p", Path: tmp.Name()})
+	if err != nil {
+		t.Fatalf("queryFileHandler error: %v", err)
+	}
+	var rows []map[string]bigquery.Value
+	tc, _ := mcp.AsTextContent(res.Content[0])
+	if err := json.Unmarshal([]byte(tc.Text), &rows); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["id"] != "1" {
+		t.Fatalf("unexpected rows: %#v", rows)
+	}
+}
+
 func TestQueryHandlerMaxBytes(t *testing.T) {
 	mock := &bq.MockClient{QueryRes: []map[string]bigquery.Value{{"id": "1"}}, DryRunRes: &bigquery.QueryStatistics{TotalBytesProcessed: 500}}
 	srv := NewServer(func(ctx context.Context, project string) (bq.Client, error) { return mock, nil })
@@ -83,6 +111,33 @@ func TestDryRunHandler(t *testing.T) {
 	res, err := srv.dryRunHandler(context.Background(), mcp.CallToolRequest{}, dryRunArgs{Project: "p", SQL: "SELECT 1"})
 	if err != nil {
 		t.Fatalf("dryRunHandler error: %v", err)
+	}
+	tc, _ := mcp.AsTextContent(res.Content[0])
+	var stats bigquery.QueryStatistics
+	if err := json.Unmarshal([]byte(tc.Text), &stats); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if stats.TotalBytesProcessed != 1234 {
+		t.Fatalf("unexpected stats: %#v", stats)
+	}
+}
+
+func TestDryRunFileHandler(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "q*.sql")
+	if err != nil {
+		t.Fatalf("create temp file: %v", err)
+	}
+	if _, err := tmp.WriteString("SELECT 1"); err != nil {
+		t.Fatalf("write temp sql: %v", err)
+	}
+	tmp.Close()
+
+	mock := &bq.MockClient{DryRunRes: &bigquery.QueryStatistics{TotalBytesProcessed: 1234}}
+	srv := NewServer(func(ctx context.Context, project string) (bq.Client, error) { return mock, nil })
+
+	res, err := srv.dryRunFileHandler(context.Background(), mcp.CallToolRequest{}, dryRunFileArgs{Project: "p", Path: tmp.Name()})
+	if err != nil {
+		t.Fatalf("dryRunFileHandler error: %v", err)
 	}
 	tc, _ := mcp.AsTextContent(res.Content[0])
 	var stats bigquery.QueryStatistics


### PR DESCRIPTION
## Summary
- add `queryfile` and `dryrunfile` tools
- update handler tests
- document new tools

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684e41bedfdc8329a6a398c612c84b9e