### PR TITLE
Limit query results to 100 rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 This repository provides a minimal Model Context Protocol (MCP) server written in Go. The server exposes tools backed by Google BigQuery:
 
 - `schema` – returns the schema of a BigQuery table
-- `query` – executes an SQL query and returns the result rows
-- `dryrun` – performs a BigQuery dry run to validate SQL and estimate costs
-- `queryfile` – executes SQL read from a file
+ - `query` – executes an SQL query and returns up to 100 result rows
+ - `dryrun` – performs a BigQuery dry run to validate SQL and estimate costs
+ - `queryfile` – executes SQL read from a file and returns up to 100 rows
 - `dryrunfile` – dry runs SQL read from a file
-- `tables` – lists tables in a BigQuery dataset
+- `tables` – lists tables in a BigQuery dataset (up to 100 entries)
+
+Query and table results are truncated to the first 100 rows to keep responses concise.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- limit query and table results to the first 100 rows
- mention the 100 row cap in tool descriptions and README
- add unit tests for result truncation

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684e445370f48329b831e108701b17f7