### PR TITLE
Refactor E2E test

### DIFF
--- a/internal/mcp/handlers.go
+++ b/internal/mcp/handlers.go
@@ -21,6 +21,11 @@ type Server struct {
 	bqClientProvider func(ctx context.Context, project string) (bigquery.Client, error)
 }
 
+// MCPServer exposes the underlying MCP server.
+func (s *Server) MCPServer() *server.MCPServer {
+	return s.mcpServer
+}
+
 type schemaArgs struct {
 	Project string `json:"project"`
 	Dataset string `json:"dataset"`


### PR DESCRIPTION
## Summary
- refactor the E2E test to use `httptest` instead of running a child process
- expose the internal MCP server for testing

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684e895df958832999c08fcbe99f34e9