### PR TITLE
Add regex filtering for table list

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,17 +2,30 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
+	"regexp"
 
 	"github.com/masudahiroto/bigquery-mcp-server/internal/bigquery"
 	"github.com/masudahiroto/bigquery-mcp-server/internal/mcp"
 )
 
 func main() {
+	filterStr := flag.String("table-filter", "", "regex to filter table names")
+	flag.Parse()
+
 	provider := func(ctx context.Context, project string) (bigquery.Client, error) {
 		return bigquery.NewClient(ctx, project)
 	}
-	srv := mcp.NewServer(provider)
+	var opts []mcp.Option
+	if *filterStr != "" {
+		if re, err := regexp.Compile(*filterStr); err == nil {
+			opts = append(opts, mcp.WithTableFilter(re))
+		} else {
+			log.Fatalf("invalid table-filter regex: %v", err)
+		}
+	}
+	srv := mcp.NewServer(provider, opts...)
 	if err := srv.Start(":8080"); err != nil {
 		log.Fatalf("failed to start MCP server: %v", err)
 	}


### PR DESCRIPTION
## Summary
- add optional regex filter to the server
- allow specifying filter via `--table-filter` flag
- filter tables in handler if regex provided
- test new filtering logic

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684e997358d88329bdc70bd2483c0ea5