### PR TITLE
Support cross-project BigQuery dataset access

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@ To run them locally:
 2. Set the following environment variables to point to a test dataset:
 
    ```bash
-   export BQ_PROJECT=your-project-id
+   export BQ_CLIENT_PROJECT=project-for-query-jobs
+   export BQ_PROJECT=project-with-dataset
    export BQ_DATASET=your_dataset
    export BQ_TABLE=your_table
    export BQ_SQL='SELECT 1 as id'

--- a/internal/bigquery/client.go
+++ b/internal/bigquery/client.go
@@ -9,10 +9,10 @@ import (
 )
 
 type Client interface {
-	GetTableSchema(ctx context.Context, datasetID, tableID string) ([]*bigquery.FieldSchema, error)
+	GetTableSchema(ctx context.Context, projectID, datasetID, tableID string) ([]*bigquery.FieldSchema, error)
 	RunQuery(ctx context.Context, sql string) ([]map[string]bigquery.Value, error)
 	DryRunQuery(ctx context.Context, sql string) (*bigquery.QueryStatistics, error)
-	ListTables(ctx context.Context, datasetID string) ([]string, error)
+	ListTables(ctx context.Context, projectID, datasetID string) ([]string, error)
 }
 
 type realClient struct {
@@ -27,8 +27,8 @@ func NewClient(ctx context.Context, projectID string) (Client, error) {
 	return &realClient{client: c}, nil
 }
 
-func (r *realClient) GetTableSchema(ctx context.Context, datasetID, tableID string) ([]*bigquery.FieldSchema, error) {
-	tbl := r.client.Dataset(datasetID).Table(tableID)
+func (r *realClient) GetTableSchema(ctx context.Context, projectID, datasetID, tableID string) ([]*bigquery.FieldSchema, error) {
+	tbl := r.client.DatasetInProject(projectID, datasetID).Table(tableID)
 	meta, err := tbl.Metadata(ctx)
 	if err != nil {
 		return nil, err
@@ -76,8 +76,8 @@ func (r *realClient) DryRunQuery(ctx context.Context, sql string) (*bigquery.Que
 	return qs, nil
 }
 
-func (r *realClient) ListTables(ctx context.Context, datasetID string) ([]string, error) {
-	it := r.client.Dataset(datasetID).Tables(ctx)
+func (r *realClient) ListTables(ctx context.Context, projectID, datasetID string) ([]string, error) {
+	it := r.client.DatasetInProject(projectID, datasetID).Tables(ctx)
 	var tables []string
 	for {
 		tbl, err := it.Next()

--- a/internal/bigquery/mock.go
+++ b/internal/bigquery/mock.go
@@ -14,7 +14,7 @@ type MockClient struct {
 	Err       error
 }
 
-func (m *MockClient) GetTableSchema(ctx context.Context, datasetID, tableID string) ([]*bigquery.FieldSchema, error) {
+func (m *MockClient) GetTableSchema(ctx context.Context, projectID, datasetID, tableID string) ([]*bigquery.FieldSchema, error) {
 	return m.SchemaRes, m.Err
 }
 
@@ -26,6 +26,6 @@ func (m *MockClient) DryRunQuery(ctx context.Context, sql string) (*bigquery.Que
 	return m.DryRunRes, m.Err
 }
 
-func (m *MockClient) ListTables(ctx context.Context, datasetID string) ([]string, error) {
+func (m *MockClient) ListTables(ctx context.Context, projectID, datasetID string) ([]string, error) {
 	return m.TablesRes, m.Err
 }

--- a/internal/mcp/handlers_test.go
+++ b/internal/mcp/handlers_test.go
@@ -20,7 +20,7 @@ func TestSchemaHandler(t *testing.T) {
 	}
 	srv := NewServer(func(ctx context.Context, project string) (bq.Client, error) { return mock, nil })
 
-	res, err := srv.schemaHandler(context.Background(), mcp.CallToolRequest{}, schemaArgs{Project: "p", Dataset: "d", Table: "t"})
+	res, err := srv.schemaHandler(context.Background(), mcp.CallToolRequest{}, schemaArgs{Project: "p", DatasetProject: "", Dataset: "d", Table: "t"})
 	if err != nil {
 		t.Fatalf("schemaHandler error: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestTablesHandler(t *testing.T) {
 	mock := &bq.MockClient{TablesRes: []string{"t1", "t2"}}
 	srv := NewServer(func(ctx context.Context, project string) (bq.Client, error) { return mock, nil })
 
-	res, err := srv.tablesHandler(context.Background(), mcp.CallToolRequest{}, tablesArgs{Project: "p", Dataset: "d"})
+	res, err := srv.tablesHandler(context.Background(), mcp.CallToolRequest{}, tablesArgs{Project: "p", DatasetProject: "", Dataset: "d"})
 	if err != nil {
 		t.Fatalf("tablesHandler error: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestTablesHandlerRowLimit(t *testing.T) {
 	mock := &bq.MockClient{TablesRes: manyTables}
 	srv := NewServer(func(ctx context.Context, project string) (bq.Client, error) { return mock, nil })
 
-	res, err := srv.tablesHandler(context.Background(), mcp.CallToolRequest{}, tablesArgs{Project: "p", Dataset: "d"})
+	res, err := srv.tablesHandler(context.Background(), mcp.CallToolRequest{}, tablesArgs{Project: "p", DatasetProject: "", Dataset: "d"})
 	if err != nil {
 		t.Fatalf("tablesHandler error: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestTablesHandlerRegexFilter(t *testing.T) {
 	re := regexp.MustCompile("^u.*")
 	srv := NewServer(func(ctx context.Context, project string) (bq.Client, error) { return mock, nil }, WithTableFilter(re))
 
-	res, err := srv.tablesHandler(context.Background(), mcp.CallToolRequest{}, tablesArgs{Project: "p", Dataset: "d"})
+	res, err := srv.tablesHandler(context.Background(), mcp.CallToolRequest{}, tablesArgs{Project: "p", DatasetProject: "", Dataset: "d"})
 	if err != nil {
 		t.Fatalf("tablesHandler error: %v", err)
 	}

--- a/scripts/run_e2e.sh
+++ b/scripts/run_e2e.sh
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 # Verify required environment variables
-: "${BQ_PROJECT?Need to set BQ_PROJECT}" 
+: "${BQ_PROJECT?Need to set BQ_PROJECT}"
+: "${BQ_CLIENT_PROJECT?Need to set BQ_CLIENT_PROJECT}" || true
 : "${BQ_DATASET?Need to set BQ_DATASET}"
 : "${BQ_TABLE?Need to set BQ_TABLE}"
 : "${BQ_SQL?Need to set BQ_SQL}"


### PR DESCRIPTION
## Summary
- allow dataset project to differ from the client project
- update handlers, interfaces and mock implementations
- extend e2e tests to set `BQ_CLIENT_PROJECT`
- update README and helper script for new variable

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684e9f7afb708329b716649d789b5107