### PR TITLE
Fix BigQuery region handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ The server listens on `:8080` by default. Use an MCP client to call the register
 
 Set the environment variable `MAX_BQ_QUERY_BYTES` to limit how many bytes a query may scan. The `query` tool performs a BigQuery dry run and refuses to execute if the estimated bytes processed exceed this value.
 
+### BigQuery Region
+
+The server reads `BQ_REGION` to set the location for all BigQuery jobs. Specify
+`US`, `EU`, or another region if your dataset is not in the default location.
+
 ## Testing
 
 Run unit tests:
@@ -66,6 +71,7 @@ To run them locally:
    export BQ_PROJECT=project-with-dataset
    export BQ_DATASET=your_dataset
    export BQ_TABLE=your_table
+   export BQ_REGION=US
    export BQ_SQL='SELECT 1 as id'
    ```
 

--- a/internal/bigquery/client.go
+++ b/internal/bigquery/client.go
@@ -3,6 +3,7 @@ package bigquery
 import (
 	"context"
 	"errors"
+	"os"
 
 	"cloud.google.com/go/bigquery"
 	"google.golang.org/api/iterator"
@@ -23,6 +24,9 @@ func NewClient(ctx context.Context, projectID string) (Client, error) {
 	c, err := bigquery.NewClient(ctx, projectID)
 	if err != nil {
 		return nil, err
+	}
+	if loc := os.Getenv("BQ_REGION"); loc != "" {
+		c.Location = loc
 	}
 	return &realClient{client: c}, nil
 }


### PR DESCRIPTION
## Summary
- allow configuring BigQuery client location via `BQ_REGION`
- document new environment variable in README

## Testing
- `go test ./...`
- `go test -tags=e2e ./e2e`

------
https://chatgpt.com/codex/tasks/task_e_6850b092ee18832990f13ae3fbc7bab8