### PR TITLE
Add startup flags for project and region

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ This downloads the module and places the compiled binary in `$(go env GOPATH)/bi
 
 ## Getting Started
 
-Run the server:
+Run the server with your Google Cloud project and BigQuery region:
 
 ```bash
-bigquery-mcp-server
+bigquery-mcp-server -project my-project -region US
 ```
 
 The server listens on `:8080` by default. Use an MCP client to call the registered tools.
@@ -42,8 +42,8 @@ Set the environment variable `MAX_BQ_QUERY_BYTES` to limit how many bytes a quer
 
 ### BigQuery Region
 
-The server reads `BQ_REGION` to set the location for all BigQuery jobs. Specify
-`US`, `EU`, or another region if your dataset is not in the default location.
+Use the `-region` flag to set the location for all BigQuery jobs. Specify `US`,
+`EU`, or another region if your dataset is not in the default location.
 
 ## Testing
 

--- a/cmd/bigquery-mcp-server/main.go
+++ b/cmd/bigquery-mcp-server/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"log"
+	"os"
 	"regexp"
 
 	"github.com/masudahiroto/bigquery-mcp-server/internal/bigquery"
@@ -11,8 +12,15 @@ import (
 )
 
 func main() {
+	projectID := flag.String("project", "", "Google Cloud project ID for BigQuery client")
+	region := flag.String("region", "", "BigQuery location for jobs")
 	filterStr := flag.String("table-filter", "", "regex to filter table names")
 	flag.Parse()
+
+	if *projectID == "" || *region == "" {
+		log.Fatal("project and region must be specified")
+	}
+	os.Setenv("BQ_REGION", *region)
 
 	provider := func(ctx context.Context, project string) (bigquery.Client, error) {
 		return bigquery.NewClient(ctx, project)
@@ -25,7 +33,7 @@ func main() {
 			log.Fatalf("invalid table-filter regex: %v", err)
 		}
 	}
-	srv := mcp.NewServer(provider, opts...)
+	srv := mcp.NewServer(provider, *projectID, opts...)
 	if err := srv.Start(":8080"); err != nil {
 		log.Fatalf("failed to start MCP server: %v", err)
 	}

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func runBigQueryScenario(t *testing.T, ctx context.Context, cli *client.Client,
-	clientProject, datasetProject, dataset, table, sql string) {
+	datasetProject, dataset, table, sql string) {
 	initReq := mcp.InitializeRequest{}
 	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 	initReq.Params.ClientInfo = mcp.Implementation{Name: "e2e-test", Version: "0.1"}
@@ -53,7 +53,6 @@ func runBigQueryScenario(t *testing.T, ctx context.Context, cli *client.Client,
 	schemaReq := mcp.CallToolRequest{}
 	schemaReq.Params.Name = "schema"
 	schemaReq.Params.Arguments = map[string]any{
-		"project":         clientProject,
 		"dataset_project": datasetProject,
 		"dataset":         dataset,
 		"table":           table,
@@ -75,8 +74,7 @@ func runBigQueryScenario(t *testing.T, ctx context.Context, cli *client.Client,
 	queryReq := mcp.CallToolRequest{}
 	queryReq.Params.Name = "query"
 	queryReq.Params.Arguments = map[string]any{
-		"project": clientProject,
-		"sql":     sql,
+		"sql": sql,
 	}
 	queryRes, err := cli.CallTool(ctx, queryReq)
 	if err != nil {
@@ -95,7 +93,6 @@ func runBigQueryScenario(t *testing.T, ctx context.Context, cli *client.Client,
 	tablesReq := mcp.CallToolRequest{}
 	tablesReq.Params.Name = "tables"
 	tablesReq.Params.Arguments = map[string]any{
-		"project":         clientProject,
 		"dataset_project": datasetProject,
 		"dataset":         dataset,
 	}
@@ -134,7 +131,7 @@ func TestBigQueryServer_TLS(t *testing.T) {
 	provider := func(ctx context.Context, project string) (bigquery.Client, error) {
 		return bigquery.NewClient(ctx, project)
 	}
-	srv := internalmcp.NewServer(provider)
+	srv := internalmcp.NewServer(provider, clientProject)
 	httpSrv := mcpserver.NewStreamableHTTPServer(srv.MCPServer())
 	ts := httptest.NewTLSServer(httpSrv)
 	defer ts.Close()
@@ -147,7 +144,7 @@ func TestBigQueryServer_TLS(t *testing.T) {
 		t.Fatalf("start client: %v", err)
 	}
 	defer cli.Close()
-	runBigQueryScenario(t, ctx, cli, clientProject, dataProject, dataset, table, sql)
+	runBigQueryScenario(t, ctx, cli, dataProject, dataset, table, sql)
 }
 
 func TestBigQueryServer_Stdio(t *testing.T) {
@@ -170,7 +167,7 @@ func TestBigQueryServer_Stdio(t *testing.T) {
 	provider := func(ctx context.Context, project string) (bigquery.Client, error) {
 		return bigquery.NewClient(ctx, project)
 	}
-	srv := internalmcp.NewServer(provider)
+	srv := internalmcp.NewServer(provider, clientProject)
 	stdioSrv := mcpserver.NewStdioServer(srv.MCPServer())
 
 	serverReader, clientWriter := io.Pipe()
@@ -188,5 +185,5 @@ func TestBigQueryServer_Stdio(t *testing.T) {
 	}
 	defer cli.Close()
 
-	runBigQueryScenario(t, ctx, cli, clientProject, dataProject, dataset, table, sql)
+	runBigQueryScenario(t, ctx, cli, dataProject, dataset, table, sql)
 }


### PR DESCRIPTION
## Summary
- make the server require `-project` and `-region` flags
- adjust README usage docs
- default tools to the project specified at startup
- update tests and e2e suite for new API

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6850ba5156a88329bb442c460c49f2c3