### PR TITLE
Fix e2e client shutdown

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -136,6 +136,7 @@ func TestBigQueryServer_TLS(t *testing.T) {
 	}
 	srv := internalmcp.NewServer(provider)
 	httpSrv := mcpserver.NewStreamableHTTPServer(srv.MCPServer())
+
 	ts := httptest.NewTLSServer(httpSrv)
 	defer ts.Close()
 
@@ -146,7 +147,12 @@ func TestBigQueryServer_TLS(t *testing.T) {
 	if err := cli.Start(ctx); err != nil {
 		t.Fatalf("start client: %v", err)
 	}
-	defer cli.Close()
+
+	defer func() {
+		cli.Close()
+		time.Sleep(100 * time.Millisecond)
+	}()
+
 	runBigQueryScenario(t, ctx, cli, clientProject, dataProject, dataset, table, sql)
 }
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -145,7 +145,7 @@ func TestBigQueryServer_TLS(t *testing.T) {
 		t.Fatalf("start client: %v", err)
 	}
 
-  defer func() {
+        defer func() {
 		cli.Close()
 		time.Sleep(100 * time.Millisecond)
 	}()


### PR DESCRIPTION
## Summary
- fix TestBigQueryServer_TLS to delay server shutdown until after client close

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6850b92631308329a743e3fa767077ab