### PR TITLE
Fix call to runBigQueryScenario

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -150,7 +150,7 @@ func TestBigQueryServer_TLS(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 	}()
 
-	runBigQueryScenario(t, ctx, cli, clientProject, dataProject, dataset, table, sql)
+       runBigQueryScenario(t, ctx, cli, dataProject, dataset, table, sql)
 }
 
 func TestBigQueryServer_Stdio(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix argument mismatch in e2e tests

## Testing
- `go test ./...`
- `BQ_CLIENT_PROJECT=bigquery-mcp-server BQ_PROJECT=bigquery-public-data BQ_DATASET=austin_311 BQ_TABLE=311_service_requests BQ_SQL="select 1" BQ_REGIONS=US ./scripts/run_e2e.sh` *(fails: credentials could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6851002b7eac83299b4a8cbb84538b7e